### PR TITLE
Fix failing test

### DIFF
--- a/pysd/py_backend/output.py
+++ b/pysd/py_backend/output.py
@@ -44,8 +44,7 @@ class ModelOutput():
         # want them to run (DataFrameHandler runs first)
         self.handler = DataFrameHandler(DatasetHandler(None)).handle(out_file)
 
-        capture_elements.append("time")
-        self.capture_elements = capture_elements
+        self.capture_elements = capture_elements + ["time"]
 
         self.initialize(model)
 


### PR DESCRIPTION
## Description

Avoids changing the state of the capture_elemets argument in the DatasetHandler. This was breaking a test, when the model was run a second time without overriding the capture_elements list.

## Related issues

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## PR verification (to be filled by reviewers)

- [ ] The code follows the [PEP 8 style](https://peps.python.org/pep-0008/)
- [ ] The new code has been tested properly for all the possible cases
- [ ] The overall coverage has not dropped and other features have not been broken.
- [ ] If new features have been added, they have been properly documented
- [ ] *docs/whats_new.rst* has been updated
- [ ] PySD version has been updated
