### PR TITLE
add importlib_metadata in requirements.txt

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -66,9 +66,16 @@ In order to plot model outputs as shown in :doc:`Getting started <../getting_sta
 
 * Matplotlib
 
-In order to be able to export data to netCDF (*.nc*) files:
+To export data to netCDF (*.nc*) files:
 
 * netCDF4
+* importlib-metadata==2.0 (only for Python 3.7)
+
+To export netCDF data to comma or tab separated files with parallel processing:
+
+* dask[array]
+* dask[diagnostics]
+* dask[distributed]
 
 
 These Python libraries bring additional data analytics capabilities to the analysis of SD models:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,3 +9,4 @@ netCDF4==1.6; platform_system != 'Windows' or python_version != "3.7"
 dask[array]
 dask[diagnostics]
 dask[distributed]
+importlib-metadata==2.0; python_version == "3.7"


### PR DESCRIPTION
## Description

xarray imports entry_points() from importlib_metadata instead of importlib.metadata for Python < 3.8.

## Related issues

(add any related issues here)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## PR verification (to be filled by reviewers)

- [ ] The code follows the [PEP 8 style](https://peps.python.org/pep-0008/)
- [ ] The new code has been tested properly for all the possible cases
- [ ] The overall coverage has not dropped and other features have not been broken.
- [ ] If new features have been added, they have been properly documented
- [ ] *docs/whats_new.rst* has been updated
- [ ] PySD version has been updated
