### PR TITLE
CI: Add weekly scheduled run to all CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@
 
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   test:


### PR DESCRIPTION
Adds a weekly scheduled run to all CI workflows, which run each Monday at 06:00 UTC. A periodically scheduled run can detect errors and warnings appearing in changes in upstream dependencies or the build environment. By having a scheduled run they can be traced back easier to a dependency or environment change, then if they would pop up in a random PR.

Also enabled triggering a run manually (the `workflow_dispatch`).