### PR TITLE
Fix issue with elmcount function when the variable to which it is assigned has subscripts

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -14,7 +14,7 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-- Set the final_subscripts to an empty list for ELMCOUNT function in :py:meth:`pysd.builders.python_exressions_builder.CallBuilder.build_function_call` (`@rogersamso <https://github.com/rogersamso>`_)
+- Set the final_subscripts to an empty dictionary for ELMCOUNT function in :py:meth:`pysd.builders.python_exressions_builder.CallBuilder.build_function_call` (`@rogersamso <https://github.com/rogersamso>`_)
 - Define comp_subtype of Unchangeable tabbed arrays as Unchangeable. This is done in :py:meth:`pysd.builders.python.python_expressions_builder.ArrayBuilder.build` (`@rogersamso <https://github.com/rogersamso>`_)
 
 Documentation

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -15,6 +15,7 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 - Set the final_subscripts to an empty list for ELMCOUNT function in :py:meth:`pysd.builders.python_exressions_builder.CallBuilder.build_function_call` (`@rogersamso <https://github.com/rogersamso>`_)
+- Define comp_subtype of Unchangeable tabbed arrays as Unchangeable. This is done in :py:meth:`pysd.builders.python.python_expressions_builder.ArrayBuilder.build` (`@rogersamso <https://github.com/rogersamso>`_)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -14,6 +14,7 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
+- Set the final_subscripts to an empty list for ELMCOUNT function in :py:meth:`pysd.builders.python_exressions_builder.CallBuilder.build_function_call` (`@rogersamso <https://github.com/rogersamso>`_)
 
 Documentation
 ~~~~~~~~~~~~~

--- a/pysd/builders/python/python_expressions_builder.py
+++ b/pysd/builders/python/python_expressions_builder.py
@@ -658,7 +658,7 @@ class CallBuilder(StructureBuilder):
             calls = {name: 1}
 
         elif self.function == "elmcount":
-            final_subscripts = []
+            final_subscripts = {}
 
         else:
             final_subscripts = self.reorder(arguments)
@@ -2003,7 +2003,7 @@ class ArrayBuilder(StructureBuilder):
             threshold=np.prod(self.value.shape)
         )
         self.component.type = "Constant"
-        self.component.subtype = "Normal"
+        self.component.subtype = self.component.subtype or "Normal"
 
         final_subs, subscripts_out =\
             self.section.subscripts.simplify_subscript_input(

--- a/pysd/builders/python/python_expressions_builder.py
+++ b/pysd/builders/python/python_expressions_builder.py
@@ -656,6 +656,10 @@ class CallBuilder(StructureBuilder):
             }
 
             calls = {name: 1}
+
+        elif self.function == "elmcount":
+            final_subscripts = []
+
         else:
             final_subscripts = self.reorder(arguments)
             if self.function == "xidz" and final_subscripts:

--- a/pysd/translators/structures/abstract_model.py
+++ b/pysd/translators/structures/abstract_model.py
@@ -87,7 +87,7 @@ class AbstractUnchangeableConstant(AbstractComponent):
     subtype: str = "Unchangeable"
 
     def __str__(self) -> str:  # pragma: no cover
-        return "AbstractLookup %s\n" % (
+        return "AbstractUnchangeableConstant %s\n" % (
             "%s" % repr(list(self.subscripts)) if self.subscripts else "")
 
 


### PR DESCRIPTION
## Description

When the ELMCOUNT function is used inside a variable with dimensions, the result of the elmcount is assumed to have those dimensions (hence the result, which is a scalar, is inadequately transposed and reshaped). However, the result of ELMCOUNT should be [dimensionless](https://www.vensim.com/documentation/fn_elmcount.html).

## Related issues

(add any related issues here)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## PR verification (to be filled by reviewers)

- [ ] The code follows the [PEP 8 style](https://peps.python.org/pep-0008/)
- [ ] The new code has been tested properly for all the possible cases
- [ ] The overall coverage has not dropped and other features have not been broken.
- [ ] If new features have been added, they have been properly documented
- [ ] *docs/whats_new.rst* has been updated
- [ ] PySD version has been updated
