### PR TITLE
Add Py 3.11 back in the CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.10']
+        python-version: ['3.7', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3
@@ -27,8 +27,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -r tests/requirements.txt
-          pip install -e .
+          pip install -U pip
+          pip install -U wheel
+          pip install --prefer-binary -r tests/requirements.txt
+          pip install --prefer-binary -e .
       - name: Test and coverage
         run: pytest tests/ --cov=pysd -n 2
       - name: Coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.10', '3.11']
+        python-version: ['3.7', '3.11']
 
     steps:
       - uses: actions/checkout@v3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,7 +8,7 @@ coverage
 coveralls
 psutil
 netCDF4==1.5.*; platform_system == 'Windows' and python_version == "3.7"
-netCDF4==1.6.*; platform_system != 'Windows' or python_version >= "3.10"
+netCDF4==1.6.*; platform_system != 'Windows' or python_version > "3.7"
 dask[array]
 dask[diagnostics]
 dask[distributed]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,5 @@
+--only-binary=netCDF4
+
 pytest
 pytest-cov
 pytest-mock
@@ -5,8 +7,8 @@ pytest-xdist
 coverage
 coveralls
 psutil
-netCDF4==1.5; platform_system == 'Windows' and python_version == "3.7"
-netCDF4==1.6; platform_system != 'Windows' or python_version == "3.10"
+netCDF4==1.5.*; platform_system == 'Windows' and python_version == "3.7"
+netCDF4==1.6.*; platform_system != 'Windows' or python_version >= "3.10"
 dask[array]
 dask[diagnostics]
 dask[distributed]


### PR DESCRIPTION
## Description

Add Python 3.11 back to CI matrix.

## Related issues

Not sure, sorry. Related to this change: https://github.com/SDXorg/pysd/commit/2a9eb2ff571344d9645456c917b16fa8eaa84497

## Type of change

- Other (CI)

## PR verification (to be filled by reviewers)

- [ ] The code follows the [PEP 8 style](https://peps.python.org/pep-0008/)
- [x] The new code has been tested properly for all the possible cases
- [x] The overall coverage has not dropped and other features have not been broken.
- [ ] If new features have been added, they have been properly documented
- [ ] *docs/whats_new.rst* has been updated
- [ ] PySD version has been updated
