### PR TITLE
Fix typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ![PySD Logo](https://raw.githubusercontent.com/SDXorg/pysd/5cc4fe5dc65e6b5140a00e87a1be9d261570ee8d/docs/images/PySD_Logo_letters.svg?style=centerme)
 
-This project is a library for running [System Dynamics](http://en.wikipedia.org/wiki/System_dynamics) models in Python, with the purpose of improving integration of *Big Data* and *Machine Learning* into the SD workflow.
+This project is a library for running [System Dynamics](http://en.wikipedia.org/wiki/System_dynamics) (SD) models in Python, with the purpose of improving integration of *Big Data* and *Machine Learning* into the SD workflow.
 
 **The current version needs to run at least Python 3.7.**
 
@@ -51,7 +51,7 @@ git clone --recursive https://github.com/SDXorg/pysd.git
 
 ## Extensions
 
-You can use PySD in [R](https://www.r-project.org/) via the [PySD2R](https://github.com/JimDuggan/pysd2r) package, also available on [cran](https://CRAN.R-project.org/package=pysd2r).
+You can use PySD in [R](https://www.r-project.org/) via the [PySD2R](https://github.com/JimDuggan/pysd2r) package, also available on [CRAN](https://CRAN.R-project.org/package=pysd2r).
 
 ## Contributing
 

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -130,11 +130,11 @@ In order to preview the needed exogenous variables, the :py:meth:`.get_dependenc
 Initializing external data from netCDF file
 -------------------------------------------
 
-IO operations are expensive, especially when reading non-binary files. This makes the model initialization process slow when lots of datasets need to be read from spreadhseet files.
+IO operations are expensive, especially when reading non-binary files. This makes the model initialization process slow when lots of datasets need to be read from spreadsheet files.
 
 From PySD 3.8, users can export a subset or all model external data to a netCDF file, and use this file for subsequent model initializations.
 
-Supose we have a model (*my_model.mdl*) that loads *param_1* from *parameters_1.xls*, *param_2* from *parameters_2.xls*, and *policy_1* and *policy_2* from *scenario.xls*. Imagine we want to test different policy configurations, by changing the values of *policy_1* and *policy_2*, while keeping all other parameters unchanged.
+Suppose we have a model (*my_model.mdl*) that loads *param_1* from *parameters_1.xls*, *param_2* from *parameters_2.xls*, and *policy_1* and *policy_2* from *scenario.xls*. Imagine we want to test different policy configurations, by changing the values of *policy_1* and *policy_2*, while keeping all other parameters unchanged.
 In this case, we might want to export the external objects that we do not intend to modify (*param_1* and *param_2*) to a netCDF file, so that they are initialized instantaneously:
 
 The code below shows how this can be achieved::
@@ -167,7 +167,7 @@ Or even::
                                                  "parameters_2.xls"],
                               exclude_externals=None)
 
-Or we could have also combined variable names and spreadhseet files in the **include_externals** arugment, the **exclude_externals** argument or both::
+Or we could have also combined variable names and spreadsheet files in the **include_externals** argument, the **exclude_externals** argument or both::
 
     import pysd
 

--- a/docs/command_line_usage.rst
+++ b/docs/command_line_usage.rst
@@ -31,7 +31,7 @@ In order to set the output file path, the *-o/--output-file* argument can be use
 .. note::
     If *-o/--output-file* is not given, the output will be saved in a *.tab*
     file that starts with the model file name followed by a time stamp to avoid
-    overwritting files.
+    overwriting files.
 
 Activate progress bar
 ^^^^^^^^^^^^^^^^^^^^^
@@ -46,7 +46,7 @@ Translation options
 
 Only translate the model file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To translate the model file and not run the model, the *-t/--trasnlate* command is provided:
+To translate the model file and not run the model, the *-t/--translate* command is provided:
 
 .. code-block:: text
 
@@ -79,7 +79,7 @@ The number of output variables can be modified by passing them as arguments sepa
 
 Note that the a single string must be passed after the *-r/return_columns* argument, containing the names of the variables separated by commas.
 
-Sometimes, variable names have special characteres, such as commas, which can happen when trying to return a variable with subscripts.
+Sometimes, variable names have special characters, such as commas, which can happen when trying to return a variable with subscripts.
 In this case we can save a *.txt* file with one variable name per row and use it as an argument:
 
 .. code-block:: text
@@ -148,7 +148,7 @@ Several variables can be changed at the same time, e.g.:
 
 Modify initial conditions of model variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Sometimes we do not want to change the actual value of a variable but we want to change its initial value instead. An example of this would be changing the initial value of a stock object. This can be done similarly to what was shown in the previos case, but using ':' instead of '=':
+Sometimes we do not want to change the actual value of a variable but we want to change its initial value instead. An example of this would be changing the initial value of a stock object. This can be done similarly to what was shown in the previous case, but using ':' instead of '=':
 
 .. code-block:: text
 

--- a/docs/complement.rst
+++ b/docs/complement.rst
@@ -7,8 +7,8 @@ A Python library for analyzing system dynamics models called the `Exploratory Mo
 
 An excellent JavaScript library called `sd.js <https://github.com/bpowers/sd.js/tree/master>`_ created by Bobby Powers at `SDlabs <http://sdlabs.io/>`_ exists as a standalone SD engine, and provides a beautiful front end. This front end could be rendered as an iPython widget to facilitate display of SD models.
 
-The `Behavior Analysis and Testing Software(BATS) <http://www.ie.boun.edu.tr/labs/sesdyn/projects/bats/index.html>`_ delveloped by `Gönenç Yücel <http://www.ie.boun.edu.tr/people/pages/yucel.html>`_ includes a really neat method for categorizing behavior modes and exploring parameter space to determine the boundaries between them.
+The `Behavior Analysis and Testing Software(BATS) <http://www.ie.boun.edu.tr/labs/sesdyn/projects/bats/index.html>`_ developed by `Gönenç Yücel <http://www.ie.boun.edu.tr/people/pages/yucel.html>`_ includes a really neat method for categorizing behavior modes and exploring parameter space to determine the boundaries between them.
 
-The `SDQC library <https://sdqc.readthedocs.io>`_ developed by Eneko Martin Martinez may be used to check the quality of the data imported by Vensim models from speadsheet files.
+The `SDQC library <https://sdqc.readthedocs.io>`_ developed by Eneko Martin Martinez may be used to check the quality of the data imported by Vensim models from spreadsheet files.
 
 The `excels2vensim library <https://excels2vensim.readthedocs.io>`_, also developed by Eneko Martin Martinez, aims to simplify the incorporation of equations from external data into Vensim.

--- a/docs/development/adding_functions.rst
+++ b/docs/development/adding_functions.rst
@@ -46,14 +46,14 @@ In order to finish the contribution, we should update the documentation. The tab
      - CallStructure('abs', (A,))
      - numpy.abs(A)
 
-To finish, we create a new release notes block at the top of `docs/whats_new.rst` file and update the software version. Commit all the changes, includying the test-models repo, and open a new PR.
+To finish, we create a new release notes block at the top of `docs/whats_new.rst` file and update the software version. Commit all the changes, including the test-models repo, and open a new PR.
 
 
 Adding a simple function
 ------------------------
 Sometimes, it would be preferable to define own Python functions. This could help to keep similar grammar to the source code, making the final model file content simpler. This example focus on a function where we are still able to use the Abstract Structure :py:class:`pysd.translators.structures.abstract_expressions.CallStructure`, but we will include a function defined in :py:mod:`pysd.py_backend.functions`.
 
-Let's suppose we want to add support for `Vensim's VECTOR SORT ORDER function <https://www.vensim.com/documentation/fn_vector_sort_order.html>`_. First of all, we may need to check Vensim's documentation to see how this function works and try to think what is the fatest way to solve it. VECTOR SORT ORDER function takes two arguments, `vector` and `direction`. The function returns the order of the elements of the `vector` based on the `direction`. Therefore, we do not need to save previous states information or to pass other information as arguments, we should have enough with a basic Python function that takes the same arguments.
+Let's suppose we want to add support for `Vensim's VECTOR SORT ORDER function <https://www.vensim.com/documentation/fn_vector_sort_order.html>`_. First of all, we may need to check Vensim's documentation to see how this function works and try to think what is the fastest way to solve it. VECTOR SORT ORDER function takes two arguments, `vector` and `direction`. The function returns the order of the elements of the `vector` based on the `direction`. Therefore, we do not need to save previous states information or to pass other information as arguments, we should have enough with a basic Python function that takes the same arguments.
 
 Then, we define the Python function based on the Vensim's documentation. We also include the docstring (with the same style as other functions) and add this function to the file :py:mod:`pysd.py_backend.functions`::
 
@@ -84,7 +84,7 @@ Then, we define the Python function based on the Vensim's documentation. We also
             return xr.DataArray(flip.values, vector.coords, vector.dims)
         return vector.argsort()
 
-Now, we need to link the defined function with its corresponent abstract representation. So we include the following entry in the :py:data:`functionspace` dictionary from :py:mod:`pysd.builders.python.python_functions.py`::
+Now, we need to link the defined function with its correspondent abstract representation. So we include the following entry in the :py:data:`functionspace` dictionary from :py:mod:`pysd.builders.python.python_functions.py`::
 
     "vector_sort_order": (
         "vector_sort_order(%(0)s, %(1)s)",
@@ -119,4 +119,4 @@ In order to finish the contribution, we should update the documentation by addin
      - CallStructure('vector_sort_order', (vec, direction))
      - vector_sort_order(vec, direction)
 
-To finish, we create a new release notes block at the top of `docs/whats_new.rst` file and update the software version. Commit all the changes, includying the test-models repo, and open a new PR.
+To finish, we create a new release notes block at the top of `docs/whats_new.rst` file and update the software version. Commit all the changes, including the test-models repo, and open a new PR.

--- a/docs/development/development_index.rst
+++ b/docs/development/development_index.rst
@@ -9,7 +9,7 @@ Developer Documentation
    adding_functions
    pysd_architecture_views/4+1view_model
 
-In order to contribut to PySD check the :doc:`guidelines` and the :doc:`pathway`.
+In order to contribute to PySD check the :doc:`guidelines` and the :doc:`pathway`.
 You also will find helpful the :doc:`Structure of the PySD library <../../structure/structure_index>` to understand better how it works.
 If you want to add a missing function to the PySD Python builder you may find useful the example in :doc:`adding_functions`.
 

--- a/docs/development/guidelines.rst
+++ b/docs/development/guidelines.rst
@@ -9,7 +9,7 @@ To get started, you can fork the repository and make contributions to your own v
 When you are happy with your edits, submit a pull request to the main branch.
 
 .. note::
-  In order to open a pull request, the new features and changes should be througly tested.
+  In order to open a pull request, the new features and changes should be thoroughly tested.
   To do so, unit tests of new features or translated functions should be added, please check the Development Tools section below. When opening a pull request all tests are run and the coverage and pep8 style are checked.
 
 Development Tools
@@ -20,7 +20,7 @@ Test Suite
 ^^^^^^^^^^
 PySD uses the common model test suite found `on github <https://github.com/SDXorg/test-models>`_
 which are run using `pytest_integration_test_vensim_pathway.py`  and `pytest_integration_test_xmile_pathway.py`.
-PySD also has own tests for internal funtionality, `pytest_*.py` files
+PySD also has own tests for internal functionality, `pytest_*.py` files
 of the `/tests/` directory.
 
 In order to run all the tests :py:mod:`pytest` should be used.
@@ -35,7 +35,7 @@ complementary tests in the corresponding `pytest_*.py` file.
 
 .. note::
   If your changes correct some existing bug related to the translation or running
-  of a Vensim (or Xmile) model. You should add a new test in the `test suite repo <https://github.com/SDXorg/test-models>`_ reproducing the solved bug and addthe necessary lines in `pytest_integration/pytest_integration_test_vensim_pathway.py` (or `pytest_integration/pytest_integration_test_xmile_pathway.py`) to run the new test. Then, it is encouraged to add also unit test in `pytest_translators` reproducing the translation of the new function and test of the workflow in
+  of a Vensim (or Xmile) model. You should add a new test in the `test suite repo <https://github.com/SDXorg/test-models>`_ reproducing the solved bug and add the necessary lines in `pytest_integration/pytest_integration_test_vensim_pathway.py` (or `pytest_integration/pytest_integration_test_xmile_pathway.py`) to run the new test. Then, it is encouraged to add also unit test in `pytest_translators` reproducing the translation of the new function and test of the workflow in
   `pytest_types/functions/pytest_functions.py` (or `pytest_types/statefuls/pytest_statefuls.py`).
 
 Speed Tests

--- a/docs/development/pysd_architecture_views/4+1view_model.rst
+++ b/docs/development/pysd_architecture_views/4+1view_model.rst
@@ -9,7 +9,7 @@ The "4+1" Model View of Software Architecture
 
 The `4+1 model view`_, designed by Philippe Krutchen, presents a way to describe the architecture of software systems, using multiple and concurrent views. This use of multiple views allows to address separately the concerns of the various 'stakeholders' of the architecture such as end-user, developers, systems engineers, project managers, etc.
 
-The software architecture deals with abstraction, with decomposition and composition, with style and system's esthetic. To describe a software architecture, we use a model formed by multiple views or perspectives. That model is made up of five main views: logical view, development view, process view, physical view and scenarios or user cases.
+The software architecture deals with abstraction, with decomposition and composition, with style and system's aesthetic. To describe a software architecture, we use a model formed by multiple views or perspectives. That model is made up of five main views: logical view, development view, process view, physical view and scenarios or user cases.
 
 * The Physical View: describes the mapping of the software onto the hardware and reflects its distributed aspect
 
@@ -37,7 +37,7 @@ A package diagram, represented in the figure `PySD development view`_, is used t
 
    PySD development view
 
-**pysd** is the main package that includes all the others and all the logic of the system. It is necessary to differentiate between the package called **pysd** and the module called pysd. The latter allows the user to interact with the system and has the appropiate functions to be able to translate a Vensim or XMILE model and, in addition, to execute the generated translation. However, the XMILE translation process is not defined in this document.
+**pysd** is the main package that includes all the others and all the logic of the system. It is necessary to differentiate between the package called **pysd** and the module called pysd. The latter allows the user to interact with the system and has the appropriate functions to be able to translate a Vensim or XMILE model and, in addition, to execute the generated translation. However, the XMILE translation process is not defined in this document.
 
 The **pysd** module interacts with the modules of the **py_backend** package. This package has two sub-packages: **vensim** and **xmile**. The **vensim** package contains all the logic needed to translate *Vensim* models.
 
@@ -156,7 +156,7 @@ Next, in `Builder module`_ figures the **builder** module. There is no class def
 
 The main function of the **builder** module is :py:func:`.build`. That function builds and writes the Python representation of the model. It is called from the **vensim2py** module after finishing the whole process  of translating the Vensim model. As parameters it is passed the different elements of the model that have been parsed, subscripts, namespace and the name of the file where the result of the Python representation should be written. This function has certain permanent lines of code that are always write in the models created, but then, there are certain lines of code that are completed with the translation generated before in the **vensim2py** module.
 
-In image `Utils module`_ is found the **utils** module. The main purpose of utils is to bring together in a single module all the functions that are useful for the project. Many of these functions are used many times during the translation process. So, as already presented in `PySD relationships between modules`_, this module is used by the **builder**, **functions**, **external** and **vensim2py** modules. In turn, the accesible names of the **decorators**, **external** and **functions** modules are imported into the **utils** modules to define a list of the names that have already been used and that have a particular meaning in the model being translated.
+In image `Utils module`_ is found the **utils** module. The main purpose of utils is to bring together in a single module all the functions that are useful for the project. Many of these functions are used many times during the translation process. So, as already presented in `PySD relationships between modules`_, this module is used by the **builder**, **functions**, **external** and **vensim2py** modules. In turn, the accessible names of the **decorators**, **external** and **functions** modules are imported into the **utils** modules to define a list of the names that have already been used and that have a particular meaning in the model being translated.
 
 .. _Utils module:
 

--- a/docs/generate_tables.py
+++ b/docs/generate_tables.py
@@ -11,7 +11,7 @@ def generate(table, columns, output):
     subtable = subtable[~subtable[columns[0]].isna()]
 
     if all(subtable[columns[-1]].isna()):
-        # if the commnets columns (last) is all na, do not save it
+        # if the comments columns (last) is all na, do not save it
         subtable = subtable[columns[:-1]]
 
     # Place an empty string where na values

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -196,7 +196,7 @@ Alternately, if we want the room temperature to vary over the course of the simu
    >>> temp = pd.Series(index=range(30), data=range(20, 80, 2))
    >>> model.run(params={'Room Temperature': temp})
 
-If the parameter value to change is a subscripted variable (vector, matrix...), there are three different options to set the new value. Suposse we have ‘Subscripted var’ with dims :py:data:`['dim1', 'dim2']` and coordinates :py:data:`{'dim1': [1, 2], 'dim2': [1, 2]}`. A constant value can be used and all the values will be replaced::
+If the parameter value to change is a subscripted variable (vector, matrix...), there are three different options to set the new value. Supposse we have ‘Subscripted var’ with dims :py:data:`['dim1', 'dim2']` and coordinates :py:data:`{'dim1': [1, 2], 'dim2': [1, 2]}`. A constant value can be used and all the values will be replaced::
 
    >>> model.run(params={'Subscripted var': 0})
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,7 @@ This project is a simple library for running System Dynamics models in Python, w
 
 PySD translates :doc:`Vensim <structure/vensim_translation>` or
 :doc:`XMILE <structure/xmile_translation>` model files into Python modules,
-and provides methods to modify, simulate, and observe those translated models. The translation is done throught an intermediate :doc:`Abstract Synatax Tree representation <structure/structure_index>`,
+and provides methods to modify, simulate, and observe those translated models. The translation is done through an intermediate :doc:`Abstract Syntax Tree representation <structure/structure_index>`,
 which makes it possible to add builders in other languages in a simpler way
 
 Why create a new SD simulation engine?
@@ -143,7 +143,7 @@ Please, also add the `PySD Introductory Paper (2015) <https://github.com/SDXorg/
       keywords = {System Dynamics, Vensim, Python}
    }
 
-You can also cite the library using the `DOI provided by Zenodo <https://doi.org/10.5281/zenodo.5654824>`_. It is recomendable to specify the used PySD version and its correspondent DOI. If you want to cite all versions you can use the generic DOI for PySD instead:
+You can also cite the library using the `DOI provided by Zenodo <https://doi.org/10.5281/zenodo.5654824>`_. It is recommendable to specify the used PySD version and its correspondent DOI. If you want to cite all versions you can use the generic DOI for PySD instead:
 
 |DOI|
 

--- a/docs/reporting_bugs.rst
+++ b/docs/reporting_bugs.rst
@@ -6,7 +6,7 @@ Before reporting any bug, please make sure that you are using the latest version
 All bugs must be reported in the project's `issue tracker on github <https://github.com/SDXorg/pysd/issues>`_.
 
 .. note::
-  Not all the features and functions are implemented. If you are in trouble while translating or running a Vensim or Xmile model check the :ref:`Vensim supported functions <Vensim supported functions>` or :ref:`Xmile supported functions <Xmile supported functions>` and consider that when openning a new issue.
+  Not all the features and functions are implemented. If you are in trouble while translating or running a Vensim or Xmile model check the :ref:`Vensim supported functions <Vensim supported functions>` or :ref:`Xmile supported functions <Xmile supported functions>` and consider that when opening a new issue.
 
 Bugs during translation
 -----------------------

--- a/docs/structure/abstract_model.rst
+++ b/docs/structure/abstract_model.rst
@@ -13,7 +13,7 @@ The :py:class:`AbstractModel` object should retain as much information from the
 original model as possible. Although the information is not used
 in the output code, it may be necessary for other future output languages
 or for improvements in the currently supported outputs. For example, currently
-unchangeable constansts (== defined in Vensim) are treated as regular
+unchangeable constants (== defined in Vensim) are treated as regular
 components with Python, but in the future we may want to protect them
 from user interaction.
 
@@ -25,7 +25,7 @@ Main abstract structures
 .. automodule:: pysd.translators.structures.abstract_model
    :members:
 
-Abstrat structures for the AST
-------------------------------
+Abstract structures for the AST
+-------------------------------
 .. automodule:: pysd.translators.structures.abstract_expressions
    :members:

--- a/docs/structure/python_builder.rst
+++ b/docs/structure/python_builder.rst
@@ -5,7 +5,7 @@ The Python builder allows to build models that can be run with the PySD Model cl
 
 The use of a one-to-one dictionary in translation means that the breadth of functionality is inherently limited. In the case where no direct Python equivalent is available, PySD provides a library of functions such as `pulse`, `step`, etc. that are specific to dynamic model behavior.
 
-In addition to translating individual commands between Vensim/XMILE and Python, PySD reworks component identifiers to be Python-safe by replacing spaces with underscores. The translator allows source identifiers to make use of alphanumeric characters, spaces, or special characteres. In order to make that possible a namespace is created, which links the original name of the variable with the Python-safe name. The namespace is also available in the PySD model class to allow users working with both original names and Python-safe names.
+In addition to translating individual commands between Vensim/XMILE and Python, PySD reworks component identifiers to be Python-safe by replacing spaces with underscores. The translator allows source identifiers to make use of alphanumeric characters, spaces, or special characters. In order to make that possible a namespace is created, which links the original name of the variable with the Python-safe name. The namespace is also available in the PySD model class to allow users working with both original names and Python-safe names.
 
 The resulting Python code from building the model is formatted with :py:mod:`black` library and it is written to the same folder where the original model is.
 

--- a/docs/structure/structure_index.rst
+++ b/docs/structure/structure_index.rst
@@ -21,7 +21,7 @@ Translation
    xmile_translation
    abstract_model
 
-PySD currentlty supports translation :doc:`from Vensim <vensim_translation>` and :doc:`from Xmile <xmile_translation>`.
+PySD currently supports translation :doc:`from Vensim <vensim_translation>` and :doc:`from Xmile <xmile_translation>`.
 
 PySD can import models in Vensim's \*.mdl file format and in XMILE format (\*.xml, \*.xmile, or \*.stmx file). `Parsimonious <https://github.com/erikrose/parsimonious>`_ is the Parsing Expression Grammar `(PEG) <https://en.wikipedia.org/wiki/Parsing_expression_grammar>`_ parser library used in PySD to parse the original models and construct an abstract syntax tree. The translators then crawl the tree, using a set of classes to define the :doc:`Abstract Model <abstract_model>`.
 
@@ -64,7 +64,7 @@ The Python model
 
 For loading a translated model with Python see :doc:`Getting started <../../getting_started>` or :doc:`Model loading <../../python_api/model_loading>`. The Python builder constructs a Python class that represents the system dynamics model. The class maintains a dictionary representing the current values of each of the system stocks, and the current simulation time, making it a `stateful` model in much the same way that the system itself has a specific state at any point in time.
 
-The :doc:`Model class <../../python_api/model_class>` also contains a function for each of the model components, representing the essential model equations. Each function contains its units, subcscripts type infromation and documentation as translated from the original model file. A query to any of the model functions will calculate and return its value according to the stored state of the system.
+The :doc:`Model class <../../python_api/model_class>` also contains a function for each of the model components, representing the essential model equations. Each function contains its units, subscripts type information and documentation as translated from the original model file. A query to any of the model functions will calculate and return its value according to the stored state of the system.
 
 The :doc:`Model class <../../python_api/model_class>` maintains only a single state of the system in memory, meaning that all functions must obey the Markov property  - that the future state of the system can be calculated entirely based upon its current state. In addition to simplifying integration, this requirement enables analyses that interact with the model at a step-by-step level.
 

--- a/docs/structure/vensim_translation.rst
+++ b/docs/structure/vensim_translation.rst
@@ -9,9 +9,9 @@ Translation workflow
 The following translation workflow allows splitting the Vensim file while parsing its contents in order to build an :py:class:`AbstractModel` object. The workflow may be summarized as follows:
 
 1. **Vensim file**: splits the model equations from the sketch and allows splitting the model in sections (main section and macro sections).
-2. **Vensim section**: is a full set of varibles and definitions that is integrable. The Vensim section can then be split into model expressions.
-3. **Vensim element**: a definition in the mdl file which could be a subscript (sub)range definition or a variable definition. It includes units and comments. Definitions for the same variable are grouped after in the same :py:class:`AbstractElement` object. Allows parsing its left hand side (LHS) to get the name of the subscript (sub)range or variable and it is returned as a specific type of component depending on the used assing operator (=, ==, :=, (), :)
-4. **Vensim component**: the classified object for a variable definition, it depends on the opperator used to define the variable. Its right hand side (RHS) can be parsed to get the Abstract Syntax Tree (AST) of the expression.
+2. **Vensim section**: is a full set of variables and definitions that is integrable. The Vensim section can then be split into model expressions.
+3. **Vensim element**: a definition in the mdl file which could be a subscript (sub)range definition or a variable definition. It includes units and comments. Definitions for the same variable are grouped after in the same :py:class:`AbstractElement` object. Allows parsing its left hand side (LHS) to get the name of the subscript (sub)range or variable and it is returned as a specific type of component depending on the used assign operator (=, ==, :=, (), :)
+4. **Vensim component**: the classified object for a variable definition, it depends on the operator used to define the variable. Its right hand side (RHS) can be parsed to get the Abstract Syntax Tree (AST) of the expression.
 
 Once the model is parsed and broken following the previous steps, the :py:class:`AbstractModel` is returned.
 
@@ -66,7 +66,7 @@ Moreover, the Vensim :EXCEPT: operator is also supported to manage exceptions in
 
 Functions
 ^^^^^^^^^
-The list of currentlty supported Vensim functions are detailed below:
+The list of currently supported Vensim functions are detailed below:
 
 .. csv-table:: Supported basic functions
    :file: ../tables/functions_vensim.csv
@@ -90,7 +90,7 @@ Stocks defined in Vensim as `INTEG(flow, initial_value)` are supported and are t
 
 Subscripts
 ^^^^^^^^^^
-Several subscript related features are also supported. Thiese include:
+Several subscript related features are also supported. These include:
 
 - Basic subscript operations with different ranges.
 - Subscript ranges and subranges definitions.
@@ -98,7 +98,7 @@ Several subscript related features are also supported. Thiese include:
 - Subscript copy (e.g. new_dim <-> dim).
 - \:EXCEPT: operator with any number of arguments.
 - Subscript usage as a variable (e.g. my_var[dim] = another var * dim).
-- Subscript vectorial opperations (e.g. SUM(my var[dim, dim!])).
+- Subscript vectorial operations (e.g. SUM(my var[dim, dim!])).
 
 Lookups
 ^^^^^^^
@@ -108,11 +108,11 @@ Data
 ^^^^
 Data definitions with GET functions and empty data definitions (no expressions, Vensim uses a VDF file) are supported. These definitions may or may not include any of the possible interpolation keywords: :INTERPOLATE:, :LOOK FORWARD:, :HOLD BACKWARD:, :RAW:. These keywords will be stored in the 'keyword' argument of :py:class:`AbstractData` as 'interpolate', 'look_forward', 'hold_backward' and 'raw', respectively. The Abstract Structure for GET XLS/DATA is given in the supported GET functions table. The Abstract Structure for the empty Data declarations is a :py:class:`DataStructure`.
 
-For the moment, any specific functions applying over data are supported (e.g. SHIFT IF TRUE, TIME SHIFT...), but new ones may be includded in the future.
+For the moment, any specific functions applying over data are supported (e.g. SHIFT IF TRUE, TIME SHIFT...), but new ones may be included in the future.
 
 Macro
 ^^^^^
-Vensim macros are supported. The macro content between the keywords \:MACRO: and \:END OF MACRO: is classified as a section of the model and is subsequently sused to build an independent section from the rest of the model.
+Vensim macros are supported. The macro content between the keywords \:MACRO: and \:END OF MACRO: is classified as a section of the model and is subsequently used to build an independent section from the rest of the model.
 
 Planed New Functions and Features
 ---------------------------------

--- a/docs/structure/xmile_translation.rst
+++ b/docs/structure/xmile_translation.rst
@@ -1,11 +1,11 @@
 Xmile Translation
 =================
 
-PySD allows parsing a Xmile file and translates the result to an :py:class:`AbstractModel` object that can be used to builde the model.
+PySD allows parsing a Xmile file and translates the result to an :py:class:`AbstractModel` object that can be used to build the model.
 
 
 .. warning::
-    Currently no Xmile users are working on the development of PySD. This is causing a gap between the Xmile and Vensim developments. Stella users are encouraged to take part in the development of PySD by includying new `test models <https://github.com/SDXorg/test-models>`_ and adding support for new functions and features.
+    Currently no Xmile users are working on the development of PySD. This is causing a gap between the Xmile and Vensim developments. Stella users are encouraged to take part in the development of PySD by including new `test models <https://github.com/SDXorg/test-models>`_ and adding support for new functions and features.
 
 
 The translation workflow
@@ -13,8 +13,8 @@ The translation workflow
 The following translation workflow allows splitting the Xmile file while parsing each part of it to build an :py:class:`AbstractModel` type object. The workflow may be summarized as follows:
 
 1. **Xmile file**: Parses the file with etree library and creates a section for the model.
-2. **Xmile section**: Full set of varibles and definitions that can be integrated. Allows splitting the model elements.
-3. **Xmile element**: A variable definition. It includes units and commnets. Allows parsing the expressions it contains and saving them inside AbstractComponents, that are part of an AbstractElement.
+2. **Xmile section**: Full set of variables and definitions that can be integrated. Allows splitting the model elements.
+3. **Xmile element**: A variable definition. It includes units and comments. Allows parsing the expressions it contains and saving them inside AbstractComponents, that are part of an AbstractElement.
 
 Once the model is parsed and split following the previous steps. The :py:class:`AbstractModel` can be returned.
 
@@ -83,7 +83,7 @@ Stocks are supported with any number of inflows and outflows. Stocks are transla
 
 Subscripts
 ^^^^^^^^^^
-Several subscript related features are supported. Thiese include:
+Several subscript related features are supported. These include:
 
 - Basic subscript operations with different ranges.
 - Subscript ranges and subranges definitions.

--- a/docs/tables/arithmetic.tab
+++ b/docs/tables/arithmetic.tab
@@ -1,10 +1,10 @@
 Arithmetic order	Operators	Operations
 0	"(), None"	"parenthesis, function call, references, no-operations"
 1	"\-"	negative value
-2	^	exponentation
+2	^	exponentiation
 3	"\*, /"	"multiplication, division"
 4	"%"	modulo
-5	"+, -"	"addition, substraction"
+5	"+, -"	"addition, subtraction"
 6	"=, <>, <, <=, >, >="	comparison
 7	"not"	unary logical operation
 8	"and, or"	binary logical operations

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -18,7 +18,7 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
-- Set the final_subscripts to an empty dictionary for ELMCOUNT function in :py:meth:`pysd.builders.python_exressions_builder.CallBuilder.build_function_call`. (`@rogersamso <https://github.com/rogersamso>`_)
+- Set the final_subscripts to an empty dictionary for ELMCOUNT function in :py:meth:`pysd.builders.python_expressions_builder.CallBuilder.build_function_call`. (`@rogersamso <https://github.com/rogersamso>`_)
 - Define comp_subtype of Unchangeable tabbed arrays as Unchangeable. This is done in :py:meth:`pysd.builders.python.python_expressions_builder.ArrayBuilder.build`. (`@rogersamso <https://github.com/rogersamso>`_)
 
 Documentation
@@ -180,7 +180,7 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 - Fix bug when a WITH LOOKUPS argument has subscripts. (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
-- Fix bug of exportig csv files with multiple subscripts variables. (`@rogersamso <https://github.com/rogersamso>`_)
+- Fix bug of exporting csv files with multiple subscripts variables. (`@rogersamso <https://github.com/rogersamso>`_)
 - Fix bug of missing dimensions in variables defined with not all the subscripts of a range (:issue:`364`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 - Fix bug when running a model with variable final time or time step and progressbar (:issue:`361`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 
@@ -533,14 +533,14 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
-- Generate the documentation of the model when loading it to avoid lossing information when replacing a variable value (:issue:`310`, :pull:`312`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
+- Generate the documentation of the model when loading it to avoid losing information when replacing a variable value (:issue:`310`, :pull:`312`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 - Make random functions return arrays of the same shape as the variable, to avoid repeating values over a dimension (:issue:`309`, :pull:`312`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 - Fix bug when Vensim's :MACRO: definition is not at the top of the model file (:issue:`306`, :pull:`312`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 - Make builder identify the subscripts using a main range and subrange to allow using subscripts as numeric values as Vensim does (:issue:`296`, :issue:`301`, :pull:`312`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 - Fix bug of missmatching of functions and lookups names (:issue:`116`, :pull:`312`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 - Parse Xmile models case insensitively and ignoring the new lines characters (:issue:`203`, :issue:`253`, :pull:`312`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 - Add support for Vensim's `\:EXCEPT\: keyword <https://www.vensim.com/documentation/exceptionequations.html>`_ (:issue:`168`, :issue:`253`, :pull:`312`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
-- Add spport for Xmile's FORCST and SAFEDIV functions (:issue:`154`, :pull:`312`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
+- Add support for Xmile's FORCST and SAFEDIV functions (:issue:`154`, :pull:`312`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 - Add subscripts support for Xmile (:issue:`289`, :pull:`312`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 - Fix numeric error bug when using :py:data:`return_timestamps` and time step with non-integer values. (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 


### PR DESCRIPTION
## Description

I opened my browser and the pinned tab displayed today was for PySD. Somehow I immediately spotted a typo in Abstract Syntax Tree, so I imported the project into PyCharm and inspected the rest of the code with the IDE assistant. I may have changed something that was not supposed, so just point that out here and I'll edit and update the commit / PR :+1: 

## Related issues

None.

## Type of change

- Other (docs)

## PR verification (to be filled by reviewers)

- [ ] The code follows the [PEP 8 style](https://peps.python.org/pep-0008/)
- [ ] The new code has been tested properly for all the possible cases
- [x] The overall coverage has not dropped and other features have not been broken.
- [ ] If new features have been added, they have been properly documented
- [ ] *docs/whats_new.rst* has been updated
- [ ] PySD version has been updated
