### PR TITLE
Allow multiple font styles in var names

### DIFF
--- a/pysd/translators/vensim/parsing_grammars/sketch.peg
+++ b/pysd/translators/vensim/parsing_grammars/sketch.peg
@@ -35,7 +35,7 @@ other_objects = other_objects_code "," anything
 
 # fonts
 font_properties = font_name? "|" font_size? "|" font_style? "|" color
-font_style =  "B" / "I" / "U" / "S" / "V"  # italics, bold, underline, etc
+font_style =  ("B" / "I" / "U" / "S" / "V")+  # italics, bold, underline, etc
 font_size =  ~r"\d+"  # this needs to be made a regex to match any font
 font_name = ~r"(?<=,)[^\|\d]+(?=\|)"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ lxml
 regex
 chardet
 black
-openpyxl>=3.1
+openpyxl>=3.1.2
 scipy
 progressbar2
 portion

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,7 +7,7 @@ pytest-xdist
 coverage
 coveralls
 psutil
-netCDF4>=1.6.*
+netCDF4>=1.6
 dask[array]
 dask[diagnostics]
 dask[distributed]


### PR DESCRIPTION
## Description

When parsing the sketch, multiple font styles may be used for variable names. Before this PR only a single style option was possible.

## Related issues

Fixes #443 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## PR verification (to be filled by reviewers)

- [ ] The code follows the [PEP 8 style](https://peps.python.org/pep-0008/)
- [ ] The new code has been tested properly for all the possible cases
- [ ] The overall coverage has not dropped and other features have not been broken.
- [ ] If new features have been added, they have been properly documented
- [ ] *docs/whats_new.rst* has been updated
- [ ] PySD version has been updated
