### PR TITLE
Fix stretch 0 random functions

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -1,6 +1,6 @@
 What's New
 ==========
-v3.14.3 (2025/XX/XX)
+v3.14.3 (2025/03/23)
 --------------------
 New Features
 ~~~~~~~~~~~~
@@ -14,6 +14,7 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 - Make XMILE operator parsing case-insensitive (:issue:`463`). (`@benslavin <https://github.com/benslavin>`_)
+- Avoid :py:class:`ZeroDivisionError` when stretch is 0 in RANDOM NORMAL and RANDOM EXPONENTIAL (:issue:`465`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 
 Documentation
 ~~~~~~~~~~~~~
@@ -23,6 +24,7 @@ Performance
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
+- Allow passing encoding for TabData files (:issue:`455`). (`@enekomartinmartinez <https://github.com/enekomartinmartinez>`_)
 
 v3.14.2 (2024/11/12)
 --------------------

--- a/pysd/builders/python/python_functions.py
+++ b/pysd/builders/python/python_functions.py
@@ -111,11 +111,14 @@ functionspace = {
         "np.random.uniform(%(0)s, %(1)s, size=%(size)s)",
         (("numpy",),)),
     "random_normal": (
-        "stats.truncnorm.rvs((%(0)s-%(2)s)/%(3)s, (%(1)s-%(2)s)/%(3)s,"
-        " loc=%(2)s, scale=%(3)s, size=%(size)s)",
-        (("scipy", "stats"),)),
+        "stats.truncnorm.rvs("
+        "xidz(%(0)s-%(2)s, %(3)s, -np.inf),"
+        "xidz(%(1)s-%(2)s, %(3)s, np.inf),"
+        "loc=%(2)s, scale=%(3)s, size=%(size)s)",
+        (("scipy", "stats"), ("numpy",), ("functions", "xidz"))),
     "random_exponential": (
-        "stats.truncexpon.rvs((%(1)s-np.maximum(%(0)s, %(2)s))/%(3)s,"
-        " loc=np.maximum(%(0)s, %(2)s), scale=%(3)s, size=%(size)s)",
-        (("scipy", "stats"), ("numpy",),)),
+        "stats.truncexpon.rvs("
+        "xidz(%(1)s-np.maximum(%(0)s, %(2)s), %(3)s, np.inf),"
+        "loc=np.maximum(%(0)s, %(2)s), scale=%(3)s, size=%(size)s)",
+        (("scipy", "stats"), ("numpy",), ("functions", "xidz"))),
 }

--- a/tests/more-tests/random/test_random_scale0.mdl
+++ b/tests/more-tests/random/test_random_scale0.mdl
@@ -1,0 +1,48 @@
+{UTF-8}
+
+normal1=
+	RANDOM NORMAL(-1, 10, 5, 0, 1)
+	~
+	~		|
+
+normal2=
+	RANDOM NORMAL(5, 7, 6, 0, 1)
+	~
+	~		|
+
+exponential1=
+	RANDOM EXPONENTIAL(1, 3, 0, 0, 1)
+	~
+	~		|
+
+exponential2=
+	RANDOM EXPONENTIAL(0, 10, 7, 0, 1)
+	~
+	~		|
+
+********************************************************
+	.Control
+********************************************************~
+		Simulation Control Parameters
+	|
+
+FINAL TIME  = 2
+	~	Month
+	~	The final time for the simulation.
+	|
+
+INITIAL TIME  = 0
+	~	Month
+	~	The initial time for the simulation.
+	|
+
+SAVEPER  =
+        TIME STEP
+	~	Month [0,?]
+	~	The frequency with which output is stored.
+	|
+
+TIME STEP  = 1
+	~	Month [0,?]
+	~	The time step for the simulation.
+	|

--- a/tests/pytest_pysd/pytest_random.py
+++ b/tests/pytest_pysd/pytest_random.py
@@ -7,6 +7,7 @@ import pandas as pd
 from scipy import stats
 
 import pysd
+from pysd.py_backend.functions import xidz
 from pysd.translators.vensim.vensim_element import Component
 from pysd.builders.python.python_expressions_builder import\
     CallBuilder, NumericBuilder

--- a/tests/pytest_pysd/pytest_random.py
+++ b/tests/pytest_pysd/pytest_random.py
@@ -79,6 +79,42 @@ class TestRandomModel:
             assert len(np.unique(values)) == np.prod(values.shape)
 
 
+class TestRandomScale0Model:
+    """Submodel selecting class"""
+    # messages for selecting submodules
+    @pytest.fixture(scope="class")
+    def model_path(self, shared_tmpdir, _root):
+        """
+        Copy test folder to a temporary folder therefore we avoid creating
+        PySD model files in the original folder
+        """
+        new_file = shared_tmpdir.joinpath("test_random_scale0.mdl")
+        shutil.copy(
+            _root.joinpath("more-tests/random/test_random_scale0.mdl"),
+            new_file
+        )
+        return new_file
+
+    def test_translate_run(self, model_path):
+        """
+        Translate the model and run it.
+        """
+        # expected file
+        model = pysd.read_vensim(model_path)
+        random_vars = [
+            "normal1",
+            "normal2",
+            "exponential1",
+            "exponential2"
+        ]
+        out = model.run(return_columns=random_vars, flatten_output=False)
+        # expected values
+        assert np.all(out['normal1'] == 5)
+        assert np.all(out['normal2'] == 6)
+        assert np.all(out['exponential1'] == 1)
+        assert np.all(out['exponential2'] == 7)
+
+
 class TestRandomVensim():
     @pytest.fixture(scope="function")
     def data_raw(self, input_file, _test_random):


### PR DESCRIPTION
## Description

Avoid `ZeroDivisionError` when stretch is 0 in RANDOM NORMAL and RANDOM EXPONENTIAL

## Related issues

#465 

## Type of change

- Bug fix 

## PR verification (to be filled by reviewers)

- [x] The code follows the [PEP 8 style](https://peps.python.org/pep-0008/)
- [x] The new code has been tested properly for all the possible cases
- [x] The overall coverage has not dropped and other features have not been broken.
- [x] If new features have been added, they have been properly documented
- [x] *docs/whats_new.rst* has been updated
- [x] PySD version has been updated
